### PR TITLE
Enumeration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+disabled_rules:
+  - identifier_name

--- a/BlueJet.xcodeproj/project.pbxproj
+++ b/BlueJet.xcodeproj/project.pbxproj
@@ -45,6 +45,17 @@
 		34792BC31F18137700457DC4 /* tooltag in Resources */ = {isa = PBXBuildFile; fileRef = 34792B731F18137700457DC4 /* tooltag */; };
 		34792BC41F18137700457DC4 /* tooltag in Resources */ = {isa = PBXBuildFile; fileRef = 34792B731F18137700457DC4 /* tooltag */; };
 		3488B69F1F1A7DC20053DAAA /* BlueJet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34792B2D1F180DA800457DC4 /* BlueJet.framework */; };
+		3488B6A41F1A92090053DAAA /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A31F1A92090053DAAA /* Query.swift */; };
+		3488B6A61F1A941F0053DAAA /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A51F1A941F0053DAAA /* Cursor.swift */; };
+		3488B6A81F1AA7B40053DAAA /* CursorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */; };
+		3488B6AA1F1AACB80053DAAA /* KeySequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A91F1AACB80053DAAA /* KeySequence.swift */; };
+		3488B6AC1F1ABE620053DAAA /* KeySequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */; };
+		3488B6AD1F1ABFDD0053DAAA /* KeySequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */; };
+		3488B6AE1F1ABFDE0053DAAA /* KeySequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */; };
+		3488B6B01F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
+		3488B6B11F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
+		3488B6B21F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
+		3488B6B31F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
 		34C5D9D81F1831560086E28D /* DBError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9D71F1831560086E28D /* DBError.swift */; };
 		34C5D9F01F18B8B00086E28D /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9EA1F18AB3E0086E28D /* EnvironmentTests.swift */; };
 		34C5D9F31F18D8880086E28D /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9F21F18D8880086E28D /* Transaction.swift */; };
@@ -130,6 +141,12 @@
 		34792B721F18137700457DC4 /* sample-mdb.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sample-mdb.txt"; sourceTree = "<group>"; };
 		34792B731F18137700457DC4 /* tooltag */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = tooltag; sourceTree = "<group>"; };
 		3488B69E1F1A7C6C0053DAAA /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		3488B6A31F1A92090053DAAA /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Query.swift; path = Sources/Query.swift; sourceTree = "<group>"; };
+		3488B6A51F1A941F0053DAAA /* Cursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Cursor.swift; path = Sources/Cursor.swift; sourceTree = "<group>"; };
+		3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CursorOperation.swift; path = Sources/CursorOperation.swift; sourceTree = "<group>"; };
+		3488B6A91F1AACB80053DAAA /* KeySequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeySequence.swift; path = Sources/KeySequence.swift; sourceTree = "<group>"; };
+		3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeySequenceTests.swift; sourceTree = "<group>"; };
+		3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyIterator.swift; path = Sources/KeyIterator.swift; sourceTree = "<group>"; };
 		34C5D9D71F1831560086E28D /* DBError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DBError.swift; path = Sources/DBError.swift; sourceTree = "<group>"; };
 		34C5D9EA1F18AB3E0086E28D /* EnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
 		34C5D9F11F18BE070086E28D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -231,11 +248,16 @@
 			children = (
 				34C5DA591F1A4F780086E28D /* BlueJet.h */,
 				34C5DA5A1F1A4F780086E28D /* Info.plist */,
+				3488B6A51F1A941F0053DAAA /* Cursor.swift */,
+				3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */,
 				34C5D9F41F18ED460086E28D /* Database.swift */,
 				34C5D9D71F1831560086E28D /* DBError.swift */,
 				34792B511F18128300457DC4 /* Environment.swift */,
+				3488B6A91F1AACB80053DAAA /* KeySequence.swift */,
+				3488B6A31F1A92090053DAAA /* Query.swift */,
 				34C5DA4A1F196FAE0086E28D /* Slice.swift */,
 				34C5D9F21F18D8880086E28D /* Transaction.swift */,
+				3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -312,6 +334,7 @@
 				34C5D9EA1F18AB3E0086E28D /* EnvironmentTests.swift */,
 				34C5D9F61F18EE820086E28D /* DatabaseTests.swift */,
 				34C5D9FA1F1936A90086E28D /* Helpers.swift */,
+				3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */,
 			);
 			path = BlueJetTests;
 			sourceTree = "<group>";
@@ -633,9 +656,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				34792B891F18137700457DC4 /* mdb.c in Sources */,
+				3488B6A81F1AA7B40053DAAA /* CursorOperation.swift in Sources */,
 				34792BA41F18137700457DC4 /* midl.c in Sources */,
+				3488B6AA1F1AACB80053DAAA /* KeySequence.swift in Sources */,
 				34C5D9F51F18ED460086E28D /* Database.swift in Sources */,
 				34C5DA4B1F196FAE0086E28D /* Slice.swift in Sources */,
+				3488B6B01F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3488B6A41F1A92090053DAAA /* Query.swift in Sources */,
+				3488B6A61F1A941F0053DAAA /* Cursor.swift in Sources */,
 				34C5D9D81F1831560086E28D /* DBError.swift in Sources */,
 				34792B521F18128300457DC4 /* Environment.swift in Sources */,
 				34C5D9F31F18D8880086E28D /* Transaction.swift in Sources */,
@@ -648,6 +676,7 @@
 			files = (
 				34792B8A1F18137700457DC4 /* mdb.c in Sources */,
 				34792BA51F18137700457DC4 /* midl.c in Sources */,
+				3488B6B21F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
 				34C5D9FD1F1950400086E28D /* Database.swift in Sources */,
 				34C5DA4D1F196FAE0086E28D /* Slice.swift in Sources */,
 				34C5D9FE1F1950400086E28D /* DBError.swift in Sources */,
@@ -662,6 +691,7 @@
 			files = (
 				34792B8B1F18137700457DC4 /* mdb.c in Sources */,
 				34792BA61F18137700457DC4 /* midl.c in Sources */,
+				3488B6B31F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
 				34C5DA011F19504E0086E28D /* Database.swift in Sources */,
 				34C5DA4E1F196FAE0086E28D /* Slice.swift in Sources */,
 				34C5DA021F19504E0086E28D /* DBError.swift in Sources */,
@@ -676,6 +706,7 @@
 			files = (
 				34C5D9F91F18EE850086E28D /* DatabaseTests.swift in Sources */,
 				34C5D9FB1F1936A90086E28D /* Helpers.swift in Sources */,
+				3488B6AC1F1ABE620053DAAA /* KeySequenceTests.swift in Sources */,
 				34C5D9F01F18B8B00086E28D /* EnvironmentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -686,6 +717,7 @@
 			files = (
 				34C5DA261F1957210086E28D /* mdb.c in Sources */,
 				34C5DA271F1957230086E28D /* midl.c in Sources */,
+				3488B6B11F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
 				34C5DA201F1956EA0086E28D /* DBError.swift in Sources */,
 				34C5DA4C1F196FAE0086E28D /* Slice.swift in Sources */,
 				34C5DA211F1956EA0086E28D /* Environment.swift in Sources */,
@@ -700,6 +732,7 @@
 			files = (
 				34C5DA351F1957E10086E28D /* DatabaseTests.swift in Sources */,
 				34C5DA341F1957E10086E28D /* EnvironmentTests.swift in Sources */,
+				3488B6AD1F1ABFDD0053DAAA /* KeySequenceTests.swift in Sources */,
 				34C5DA361F1957E10086E28D /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -710,6 +743,7 @@
 			files = (
 				34C5DA441F1959030086E28D /* DatabaseTests.swift in Sources */,
 				34C5DA431F1959030086E28D /* EnvironmentTests.swift in Sources */,
+				3488B6AE1F1ABFDE0053DAAA /* KeySequenceTests.swift in Sources */,
 				34C5DA451F1959030086E28D /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BlueJet.xcodeproj/project.pbxproj
+++ b/BlueJet.xcodeproj/project.pbxproj
@@ -56,6 +56,29 @@
 		3488B6B11F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
 		3488B6B21F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
 		3488B6B31F1BDDD40053DAAA /* KeyIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */; };
+		3488B6BD1F1D506A0053DAAA /* KeyValueIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */; };
+		3488B6BF1F1D51CF0053DAAA /* KeyValueSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */; };
+		3488B6C11F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6C01F1D52850053DAAA /* KeyValueSequenceTests.swift */; };
+		3488B6C21F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6C01F1D52850053DAAA /* KeyValueSequenceTests.swift */; };
+		3488B6C31F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6C01F1D52850053DAAA /* KeyValueSequenceTests.swift */; };
+		3488B6C41F1D5ACB0053DAAA /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A31F1A92090053DAAA /* Query.swift */; };
+		3488B6C51F1D5ACC0053DAAA /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A31F1A92090053DAAA /* Query.swift */; };
+		3488B6C61F1D5ACC0053DAAA /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A31F1A92090053DAAA /* Query.swift */; };
+		3488B6C71F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */; };
+		3488B6C81F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */; };
+		3488B6C91F1D5AD00053DAAA /* KeyValueSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */; };
+		3488B6CA1F1D5AD20053DAAA /* KeyValueIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */; };
+		3488B6CB1F1D5AD30053DAAA /* KeyValueIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */; };
+		3488B6CC1F1D5AD40053DAAA /* KeyValueIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */; };
+		3488B6CD1F1D5AD60053DAAA /* KeySequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A91F1AACB80053DAAA /* KeySequence.swift */; };
+		3488B6CE1F1D5AD70053DAAA /* KeySequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A91F1AACB80053DAAA /* KeySequence.swift */; };
+		3488B6CF1F1D5AD70053DAAA /* KeySequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A91F1AACB80053DAAA /* KeySequence.swift */; };
+		3488B6D01F1D5ADE0053DAAA /* CursorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */; };
+		3488B6D11F1D5ADE0053DAAA /* CursorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */; };
+		3488B6D21F1D5AE00053DAAA /* CursorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A71F1AA7B40053DAAA /* CursorOperation.swift */; };
+		3488B6D31F1D5AE30053DAAA /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A51F1A941F0053DAAA /* Cursor.swift */; };
+		3488B6D41F1D5AE30053DAAA /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A51F1A941F0053DAAA /* Cursor.swift */; };
+		3488B6D51F1D5AE40053DAAA /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3488B6A51F1A941F0053DAAA /* Cursor.swift */; };
 		34C5D9D81F1831560086E28D /* DBError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9D71F1831560086E28D /* DBError.swift */; };
 		34C5D9F01F18B8B00086E28D /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9EA1F18AB3E0086E28D /* EnvironmentTests.swift */; };
 		34C5D9F31F18D8880086E28D /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C5D9F21F18D8880086E28D /* Transaction.swift */; };
@@ -147,6 +170,9 @@
 		3488B6A91F1AACB80053DAAA /* KeySequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeySequence.swift; path = Sources/KeySequence.swift; sourceTree = "<group>"; };
 		3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeySequenceTests.swift; sourceTree = "<group>"; };
 		3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyIterator.swift; path = Sources/KeyIterator.swift; sourceTree = "<group>"; };
+		3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyValueIterator.swift; path = Sources/KeyValueIterator.swift; sourceTree = "<group>"; };
+		3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyValueSequence.swift; path = Sources/KeyValueSequence.swift; sourceTree = "<group>"; };
+		3488B6C01F1D52850053DAAA /* KeyValueSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueSequenceTests.swift; sourceTree = "<group>"; };
 		34C5D9D71F1831560086E28D /* DBError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DBError.swift; path = Sources/DBError.swift; sourceTree = "<group>"; };
 		34C5D9EA1F18AB3E0086E28D /* EnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
 		34C5D9F11F18BE070086E28D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -253,11 +279,13 @@
 				34C5D9F41F18ED460086E28D /* Database.swift */,
 				34C5D9D71F1831560086E28D /* DBError.swift */,
 				34792B511F18128300457DC4 /* Environment.swift */,
+				3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */,
 				3488B6A91F1AACB80053DAAA /* KeySequence.swift */,
+				3488B6BC1F1D506A0053DAAA /* KeyValueIterator.swift */,
+				3488B6BE1F1D51CF0053DAAA /* KeyValueSequence.swift */,
 				3488B6A31F1A92090053DAAA /* Query.swift */,
 				34C5DA4A1F196FAE0086E28D /* Slice.swift */,
 				34C5D9F21F18D8880086E28D /* Transaction.swift */,
-				3488B6AF1F1BDDD40053DAAA /* KeyIterator.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -335,6 +363,7 @@
 				34C5D9F61F18EE820086E28D /* DatabaseTests.swift */,
 				34C5D9FA1F1936A90086E28D /* Helpers.swift */,
 				3488B6AB1F1ABE620053DAAA /* KeySequenceTests.swift */,
+				3488B6C01F1D52850053DAAA /* KeyValueSequenceTests.swift */,
 			);
 			path = BlueJetTests;
 			sourceTree = "<group>";
@@ -661,10 +690,12 @@
 				3488B6AA1F1AACB80053DAAA /* KeySequence.swift in Sources */,
 				34C5D9F51F18ED460086E28D /* Database.swift in Sources */,
 				34C5DA4B1F196FAE0086E28D /* Slice.swift in Sources */,
+				3488B6BF1F1D51CF0053DAAA /* KeyValueSequence.swift in Sources */,
 				3488B6B01F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
 				3488B6A41F1A92090053DAAA /* Query.swift in Sources */,
 				3488B6A61F1A941F0053DAAA /* Cursor.swift in Sources */,
 				34C5D9D81F1831560086E28D /* DBError.swift in Sources */,
+				3488B6BD1F1D506A0053DAAA /* KeyValueIterator.swift in Sources */,
 				34792B521F18128300457DC4 /* Environment.swift in Sources */,
 				34C5D9F31F18D8880086E28D /* Transaction.swift in Sources */,
 			);
@@ -674,13 +705,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3488B6D11F1D5ADE0053DAAA /* CursorOperation.swift in Sources */,
 				34792B8A1F18137700457DC4 /* mdb.c in Sources */,
+				3488B6C51F1D5ACC0053DAAA /* Query.swift in Sources */,
 				34792BA51F18137700457DC4 /* midl.c in Sources */,
 				3488B6B21F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3488B6C81F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5D9FD1F1950400086E28D /* Database.swift in Sources */,
 				34C5DA4D1F196FAE0086E28D /* Slice.swift in Sources */,
+				3488B6CB1F1D5AD30053DAAA /* KeyValueIterator.swift in Sources */,
+				3488B6D41F1D5AE30053DAAA /* Cursor.swift in Sources */,
 				34C5D9FE1F1950400086E28D /* DBError.swift in Sources */,
 				34C5D9FF1F1950400086E28D /* Environment.swift in Sources */,
+				3488B6CE1F1D5AD70053DAAA /* KeySequence.swift in Sources */,
 				34C5DA001F1950400086E28D /* Transaction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -689,13 +726,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3488B6D21F1D5AE00053DAAA /* CursorOperation.swift in Sources */,
 				34792B8B1F18137700457DC4 /* mdb.c in Sources */,
+				3488B6C61F1D5ACC0053DAAA /* Query.swift in Sources */,
 				34792BA61F18137700457DC4 /* midl.c in Sources */,
 				3488B6B31F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3488B6C71F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5DA011F19504E0086E28D /* Database.swift in Sources */,
 				34C5DA4E1F196FAE0086E28D /* Slice.swift in Sources */,
+				3488B6CA1F1D5AD20053DAAA /* KeyValueIterator.swift in Sources */,
+				3488B6D51F1D5AE40053DAAA /* Cursor.swift in Sources */,
 				34C5DA021F19504E0086E28D /* DBError.swift in Sources */,
 				34C5DA031F19504E0086E28D /* Environment.swift in Sources */,
+				3488B6CF1F1D5AD70053DAAA /* KeySequence.swift in Sources */,
 				34C5DA041F19504E0086E28D /* Transaction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -707,6 +750,7 @@
 				34C5D9F91F18EE850086E28D /* DatabaseTests.swift in Sources */,
 				34C5D9FB1F1936A90086E28D /* Helpers.swift in Sources */,
 				3488B6AC1F1ABE620053DAAA /* KeySequenceTests.swift in Sources */,
+				3488B6C11F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */,
 				34C5D9F01F18B8B00086E28D /* EnvironmentTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -715,13 +759,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3488B6D01F1D5ADE0053DAAA /* CursorOperation.swift in Sources */,
 				34C5DA261F1957210086E28D /* mdb.c in Sources */,
+				3488B6C41F1D5ACB0053DAAA /* Query.swift in Sources */,
 				34C5DA271F1957230086E28D /* midl.c in Sources */,
 				3488B6B11F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3488B6C91F1D5AD00053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5DA201F1956EA0086E28D /* DBError.swift in Sources */,
 				34C5DA4C1F196FAE0086E28D /* Slice.swift in Sources */,
+				3488B6CC1F1D5AD40053DAAA /* KeyValueIterator.swift in Sources */,
+				3488B6D31F1D5AE30053DAAA /* Cursor.swift in Sources */,
 				34C5DA211F1956EA0086E28D /* Environment.swift in Sources */,
 				34C5DA221F1956EA0086E28D /* Transaction.swift in Sources */,
+				3488B6CD1F1D5AD60053DAAA /* KeySequence.swift in Sources */,
 				34C5DA1F1F1956EA0086E28D /* Database.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -733,6 +783,7 @@
 				34C5DA351F1957E10086E28D /* DatabaseTests.swift in Sources */,
 				34C5DA341F1957E10086E28D /* EnvironmentTests.swift in Sources */,
 				3488B6AD1F1ABFDD0053DAAA /* KeySequenceTests.swift in Sources */,
+				3488B6C21F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */,
 				34C5DA361F1957E10086E28D /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -744,6 +795,7 @@
 				34C5DA441F1959030086E28D /* DatabaseTests.swift in Sources */,
 				34C5DA431F1959030086E28D /* EnvironmentTests.swift in Sources */,
 				3488B6AE1F1ABFDE0053DAAA /* KeySequenceTests.swift in Sources */,
+				3488B6C31F1D52850053DAAA /* KeyValueSequenceTests.swift in Sources */,
 				34C5DA451F1959030086E28D /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BlueJet.xcodeproj/project.pbxproj
+++ b/BlueJet.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3429A42D1F1E07D50028C077 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3429A42C1F1E07D50028C077 /* Utility.swift */; };
+		3429A42E1F1E07D50028C077 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3429A42C1F1E07D50028C077 /* Utility.swift */; };
+		3429A42F1F1E07D50028C077 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3429A42C1F1E07D50028C077 /* Utility.swift */; };
+		3429A4301F1E07D50028C077 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3429A42C1F1E07D50028C077 /* Utility.swift */; };
 		34792B4B1F18121A00457DC4 /* BlueJet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34792B121F180D7800457DC4 /* BlueJet.framework */; };
 		34792B521F18128300457DC4 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34792B511F18128300457DC4 /* Environment.swift */; };
 		34792B751F18137700457DC4 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 34792B591F18137700457DC4 /* .gitignore */; };
@@ -131,6 +135,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3429A42C1F1E07D50028C077 /* Utility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utility.swift; path = Sources/Utility.swift; sourceTree = "<group>"; };
 		34792B121F180D7800457DC4 /* BlueJet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BlueJet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		34792B201F180D8E00457DC4 /* BlueJet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BlueJet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		34792B2D1F180DA800457DC4 /* BlueJet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BlueJet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -286,6 +291,7 @@
 				3488B6A31F1A92090053DAAA /* Query.swift */,
 				34C5DA4A1F196FAE0086E28D /* Slice.swift */,
 				34C5D9F21F18D8880086E28D /* Transaction.swift */,
+				3429A42C1F1E07D50028C077 /* Utility.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -689,6 +695,7 @@
 				34792BA41F18137700457DC4 /* midl.c in Sources */,
 				3488B6AA1F1AACB80053DAAA /* KeySequence.swift in Sources */,
 				34C5D9F51F18ED460086E28D /* Database.swift in Sources */,
+				3429A42D1F1E07D50028C077 /* Utility.swift in Sources */,
 				34C5DA4B1F196FAE0086E28D /* Slice.swift in Sources */,
 				3488B6BF1F1D51CF0053DAAA /* KeyValueSequence.swift in Sources */,
 				3488B6B01F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
@@ -710,6 +717,7 @@
 				3488B6C51F1D5ACC0053DAAA /* Query.swift in Sources */,
 				34792BA51F18137700457DC4 /* midl.c in Sources */,
 				3488B6B21F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3429A42F1F1E07D50028C077 /* Utility.swift in Sources */,
 				3488B6C81F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5D9FD1F1950400086E28D /* Database.swift in Sources */,
 				34C5DA4D1F196FAE0086E28D /* Slice.swift in Sources */,
@@ -731,6 +739,7 @@
 				3488B6C61F1D5ACC0053DAAA /* Query.swift in Sources */,
 				34792BA61F18137700457DC4 /* midl.c in Sources */,
 				3488B6B31F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3429A4301F1E07D50028C077 /* Utility.swift in Sources */,
 				3488B6C71F1D5ACF0053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5DA011F19504E0086E28D /* Database.swift in Sources */,
 				34C5DA4E1F196FAE0086E28D /* Slice.swift in Sources */,
@@ -764,6 +773,7 @@
 				3488B6C41F1D5ACB0053DAAA /* Query.swift in Sources */,
 				34C5DA271F1957230086E28D /* midl.c in Sources */,
 				3488B6B11F1BDDD40053DAAA /* KeyIterator.swift in Sources */,
+				3429A42E1F1E07D50028C077 /* Utility.swift in Sources */,
 				3488B6C91F1D5AD00053DAAA /* KeyValueSequence.swift in Sources */,
 				34C5DA201F1956EA0086E28D /* DBError.swift in Sources */,
 				34C5DA4C1F196FAE0086E28D /* Slice.swift in Sources */,

--- a/BlueJet.xcodeproj/xcshareddata/xcschemes/BlueJet iOS.xcscheme
+++ b/BlueJet.xcodeproj/xcshareddata/xcschemes/BlueJet iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 
 BlueJet is a modern Swift/Cocoa wrapper around Lightning Memory-Mapped Database Manager (LMDB). It fully utilises the multi-threaded access, transations and provides a simple enumeration interface for fetching subsets of the database. Key/Value pairs are using Swift's Encoder/Decoder protocol when dealing with the data.
 
+### Value Type-oriented
+
+With many data persistence options available for both Cocoa (Touch) and Server-side Swift BlueJet aims to be the simplest and fast Value Type store without the complexity of confusing query language, sub-classing your data models or large set of dependencies. This framework is designed to take any Swift's value type such as String, Int, Float and Data but also provide set of protocols to allow for custom type-to-Data conversion.
+
+### Encoder/Decoder support
+
+With the upcoming release of Swift 4, BlueJet will support `struct` encoder/decoder features making it even easier to store any data you use within your app.
+
 ## What is LMDB?
 
-LMDB is an incredibly fast key-value store written by Howard Chu for the OpenLDAP project. Given the nature of LDAP workloads the design of LMDB is read-optimised (but writes are super fast too!). This particular database allows for multiple databases within one environment which makes separating different data sets much easier to handle. It also allows for multiple processes to access a single database without locking it and supports transactions for making series of fail-safe reads/write routines. For more details on the design and implementation of LMDB go to [HERE].
+LMDB is an incredibly fast key-value store written by Howard Chu for the OpenLDAP project. Given the nature of LDAP workloads the design of LMDB is read-optimised (but writes are super fast too!). This particular database allows for multiple databases within one environment which makes separating different data sets much easier to handle. It also allows for multiple processes to access a single database without locking it and supports transactions for making series of fail-safe reads/write routines. For more details on the design and implementation of LMDB go to [the website](https://symas.com/lightning-memory-mapped-database/).
 
 ## Installation
 
@@ -28,11 +36,31 @@ carthage update --use-submodules
 
 ### Swift Package Manager
 
-**TODO**
+Add BlueJet as a dependency in your `Package.swift` file and import it in your project:
+
+```swift
+import PackageDescription
+
+let package = Package(
+    name: "YourGreatNewProject",
+    dependencies: [
+        .Package(url: "https://github.com/bobek-balinek/BlueJet.git", majorVersion: 0, minor: 1)
+    ]
+)
+
+```
 
 ## Basic Usage
 
-**TODO**
+### Data (De)Serialisation
+
+### Getting data
+
+### Storing data
+
+### Enumeration
+
+### Storage protocol
 
 ## Documentation
 

--- a/Sources/Cursor.swift
+++ b/Sources/Cursor.swift
@@ -15,7 +15,7 @@ import CLMDB
 public class Cursor {
 
     /// Type alias for a Key/Value tuple
-    public typealias KeyValuePair = (key: Data?, value: Data?)
+    public typealias KeyValuePair = (key: Data, value: Data?)
 
     /// Query used to position cursor at
     public let query: Query
@@ -82,14 +82,18 @@ public class Cursor {
         let op: MDB_cursor_op = MDB_cursor_op(rawValue: operation.rawValue)
 
         do {
-            try validateGet(mdb_cursor_get(self.pointer, &keyValue, &value, op))
+            try validateGet(mdb_cursor_get(pointer, &keyValue, &value, op))
 
             if value.mv_size == 0 {
                 return nil
             }
 
+            guard let key = Data(data: mdbToRawPointer(keyValue)) else {
+                return nil
+            }
+
             return (
-                Data(data: mdbToRawPointer(keyValue)),
+                key,
                 Data(data: mdbToRawPointer(value))
             )
         } catch let error {

--- a/Sources/Cursor.swift
+++ b/Sources/Cursor.swift
@@ -36,7 +36,7 @@ public class Cursor {
 
         do {
             try setup(transaction)
-            _ = try get(query.startKey, operation)
+            _ = try get(query.start, operation)
         } catch {
             lastError = error
         }
@@ -57,7 +57,7 @@ public class Cursor {
     /// When start key is not specified it will go to the start/end of the database
     /// Otherwise the cursor will be set at the start key
     var operation: CursorOperation {
-        guard query.startKey == nil else {
+        guard query.start == nil else {
             return .set
         }
 

--- a/Sources/Cursor.swift
+++ b/Sources/Cursor.swift
@@ -1,0 +1,156 @@
+//
+//  Cursor.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 15/07/2017.
+//
+//
+
+import Foundation
+#if SWIFT_PACKAGE
+import CLMDB
+#endif
+
+/// Cursor class
+public class Cursor {
+
+    /// Type alias for a Key/Value tuple
+    public typealias KeyValuePair = (key: Data?, value: Data?)
+
+    /// Query used to position cursor at
+    public let query: Query
+
+    /// Pointer to the database instance
+    internal private(set) var pointer: OpaquePointer?
+
+    /// Last occurred error. Used to check validity of the cursor
+    internal private(set) var lastError: Error?
+
+    /// Initialise a curosr within given read-only operation
+    ///
+    /// - Parameters:
+    ///   - transaction: Read-only transaction
+    ///   - query: Query to setup cursor behaviour
+    public init(transaction: Transaction, query: Query) {
+        self.query = query
+
+        do {
+            try setup(transaction)
+            _ = try get(query.startKey, operation)
+        } catch {
+            lastError = error
+        }
+    }
+
+    deinit {
+        if pointer != nil {
+            mdb_cursor_close(pointer)
+        }
+    }
+
+    /// Valid cursor has not received any operation errors
+    var isValid: Bool {
+        return lastError == nil
+    }
+
+    /// Initial operation for given cursor
+    /// When start key is not specified it will go to the start/end of the database
+    /// Otherwise the cursor will be set at the start key
+    var operation: CursorOperation {
+        guard query.startKey == nil else {
+            return .set
+        }
+
+        return query.reversed ? .last : .first
+    }
+
+    /// Next operation is used when iterating over key/value pairs
+    var nextOperation: CursorOperation {
+        return query.reversed ? .previous : .next
+    }
+
+    /// Get item from a database
+    ///
+    /// - Parameters:
+    ///   - key: The key to search for in the database
+    ///   - operation: A cursor operation
+    /// - Returns: Key/Value pair
+    /// - throws: Operation error. See `DBError`.
+    public func get(_ key: Slice?, _ operation: CursorOperation) throws -> KeyValuePair? {
+        var keyValue: MDB_val = key?.mdbValue() ?? MDB_val()
+        var value: MDB_val = MDB_val()
+        let op: MDB_cursor_op = MDB_cursor_op(rawValue: operation.rawValue)
+
+        do {
+            try validateGet(mdb_cursor_get(self.pointer, &keyValue, &value, op))
+
+            if value.mv_size == 0 {
+                return nil
+            }
+
+            return (
+                Data(data: mdbToRawPointer(keyValue)),
+                Data(data: mdbToRawPointer(value))
+            )
+        } catch let error {
+            throw error
+        }
+    }
+
+    /// Compare two keys using byte-comparison. 
+    /// This is particularly useful when dealing with strings
+    ///
+    /// - Parameters:
+    ///   - key: A key to compare with
+    ///   - otherKey: Another key to compare
+    /// - Returns: `ComparisonResult` value  
+    public func compare(_ key: Slice, with otherKey: Slice) -> ComparisonResult? {
+        return key.slice { (aPointer) in
+            return otherKey.slice { (bPointer) in
+                var cmp = memcmp(aPointer.baseAddress!, bPointer.baseAddress!, min(aPointer.count, bPointer.count))
+
+                if cmp == 0 {
+                    cmp = Int32(aPointer.count - bPointer.count)
+                }
+
+                return ComparisonResult(rawValue: (cmp < 0) ? -1 : (cmp > 0) ? 1 : 0)!
+            }
+        }
+    }
+
+    // MARK: - Internal
+
+    /// Setup cursor or renew it
+    ///
+    /// - Parameter transaction: Transaction is required
+    /// - throws: Operation error. See `DBError`.
+    internal func setup(_ transaction: Transaction) throws {
+        guard pointer == nil else {
+            try validate(mdb_cursor_renew(transaction.pointer, pointer))
+            return
+        }
+
+        try validate(mdb_cursor_open(transaction.pointer, query.database.pointer, &pointer))
+    }
+
+    /// Check if given status code is valid
+    ///
+    /// - Parameter statusCode: Status code returned from invoking LMDB functions
+    /// - throws: Operation error. See `DBError`.
+    internal func validate(_ statusCode: Int32) throws {
+        if statusCode != MDB_SUCCESS {
+            throw DBError(code: statusCode)
+        }
+    }
+
+    /// Check if given status code is valid or not found
+    /// Throws an error if otherwise
+    ///
+    /// - Parameter statusCode: Status code returned from invoking LMDB functions
+    /// - throws: Operation error. See `DBError`.
+    internal func validateGet(_ statusCode: Int32) throws {
+        if statusCode != MDB_SUCCESS && statusCode != MDB_NOTFOUND {
+            throw DBError(code: statusCode)
+        }
+    }
+}

--- a/Sources/CursorOperation.swift
+++ b/Sources/CursorOperation.swift
@@ -1,0 +1,102 @@
+//
+//  CursorOperation.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 15/07/2017.
+//
+//
+
+import Foundation
+#if SWIFT_PACKAGE
+import CLMDB
+#endif
+
+/// Cursor Get Operations
+public struct CursorOperation {
+    /// Raw value
+    public let rawValue: UInt32
+
+    /// Initialise with `MDB_cursor_op`
+    ///
+    /// - Parameter rawValue: Status code received from LMDB
+    public init(_ rawValue: UInt32) { self.rawValue = rawValue}
+
+    // MARK: - First
+
+    /// Positions the cursor at first key/value item
+    public static let first: CursorOperation = CursorOperation(MDB_FIRST.rawValue)
+
+    /// Position at first data item of current key.
+    public static let firstDup: CursorOperation = CursorOperation(MDB_FIRST_DUP.rawValue)
+
+    // MARK: - Last
+
+    /// Position at last key/data item
+    public static let last: CursorOperation = CursorOperation(MDB_LAST.rawValue)
+
+    /// Position at last data item of current key.
+    /// Only for #MDB_DUPSORT
+    public static let lastDup: CursorOperation = CursorOperation(MDB_LAST_DUP.rawValue)
+
+    // MARK: - Next
+
+    /// Position at next data item
+    public static let next: CursorOperation = CursorOperation(MDB_NEXT.rawValue)
+
+    /// Position at next data item of current key.
+    /// Only for #MDB_DUPSORT
+    public static let nextDup: CursorOperation = CursorOperation(MDB_NEXT_DUP.rawValue)
+
+    /// Position at first data item of next key
+    public static let nextNoDup: CursorOperation = CursorOperation(MDB_NEXT_NODUP.rawValue)
+
+    /// Return key and up to a page of duplicate data items from next cursor position.
+    /// Move cursor to prepare for #MDB_NEXT_MULTIPLE.
+    /// Only for #MDB_DUPSORT
+    public static let nextMultiple: CursorOperation = CursorOperation(MDB_NEXT_MULTIPLE.rawValue)
+
+    // MARK: - Previous
+
+    /// Position at previous data item
+    public static let previous: CursorOperation = CursorOperation(MDB_PREV.rawValue)
+
+    /// Position at previous data item of current key.
+    /// Only for #MDB_DUPSORT
+    public static let previousDup: CursorOperation = CursorOperation(MDB_PREV_DUP.rawValue)
+
+    /// Position at last data item of previous key
+    public static let previousNoDup: CursorOperation = CursorOperation(MDB_PREV_NODUP.rawValue)
+
+    /// Position at previous page and return key and up to a page of duplicate data items.
+    /// Only for #MDB_DUPFIXED
+    public static let previousMultiple: CursorOperation = CursorOperation(MDB_PREV_NODUP.rawValue)
+
+    // MARK: - Get
+
+    /// Position at key/data pair.
+    /// Only for #MDB_DUPSORT
+    public static let getBoth: CursorOperation = CursorOperation(MDB_GET_BOTH.rawValue)
+
+    /// Position at key, nearest data.
+    /// Only for #MDB_DUPSORT
+    public static let getBothRange: CursorOperation = CursorOperation(MDB_GET_BOTH_RANGE.rawValue)
+
+    /// Return key/data at current cursor position
+    public static let getCurrent: CursorOperation = CursorOperation(MDB_GET_CURRENT.rawValue)
+
+    /// Return key and up to a page of duplicate data items from current cursor position.
+    /// Move cursor to prepare for #MDB_NEXT_MULTIPLE.
+    /// Only for #MDB_DUPSORT
+    public static let getMultiple: CursorOperation = CursorOperation(MDB_GET_MULTIPLE.rawValue)
+
+    // MARK: - Set
+
+    /// Position at specified key
+    public static let set: CursorOperation = CursorOperation(MDB_SET.rawValue)
+
+    /// Position at specified key, return key + data
+    public static let setKey: CursorOperation = CursorOperation(MDB_SET_KEY.rawValue)
+
+    /// Position at first key greater than or equal to specified key
+    public static let setRange: CursorOperation = CursorOperation(MDB_SET_RANGE.rawValue)
+}

--- a/Sources/Database.swift
+++ b/Sources/Database.swift
@@ -308,10 +308,22 @@ public class Database {
     ///   - start: Key to start the iteration with
     ///   - end: Key to end the iteration at
     ///   - reversed: Reverse order
-    /// - Returns: Instance of the KeySequence
+    /// - Returns: Instance of the `KeySequence`
     func keyIterator(start: String? = nil, end: String? = nil, reversed: Bool = false) -> KeySequence {
         let query = Query(startKey: start, endKey: end, reversed: reversed, database: self)
         return KeySequence(query: query)
+    }
+
+    /// Create a new key+value iterator for given params
+    ///
+    /// - Parameters:
+    ///   - start: Key to start the iteration with
+    ///   - end: Key to end the iteration at
+    ///   - reversed: Reverse order
+    /// - Returns: Instance of the `KeyValueSequence`
+    func keyValueIterator(start: String? = nil, end: String? = nil, reversed: Bool = false) -> KeyValueSequence {
+        let query = Query(startKey: start, endKey: end, reversed: reversed, database: self)
+        return KeyValueSequence(query: query)
     }
 
     // MARK: - Class methods

--- a/Sources/Database.swift
+++ b/Sources/Database.swift
@@ -11,7 +11,6 @@ import Foundation
 import CLMDB
 #endif
 
-
 /// Convert bytes at given memory pointer to `MDB_val` structure
 ///
 /// - Parameter buf: Pointer to the data
@@ -78,7 +77,7 @@ public class Database {
 
         /// Just reserve space for data, don't copy it. Return a pointer to the reserved space.
         public static let reserve = PutFlags(rawValue: MDB_RESERVE)
-        
+
         /// Data is being appended, don't split full pages
         public static let append = PutFlags(rawValue: MDB_APPEND)
 
@@ -301,7 +300,21 @@ public class Database {
         }
     }
 
-    // MARK: Class methods
+    // MARK: - Iterators
+
+    /// Create a new key iterator for given params
+    ///
+    /// - Parameters:
+    ///   - start: Key to start the iteration with
+    ///   - end: Key to end the iteration at
+    ///   - reversed: Reverse order
+    /// - Returns: Instance of the KeySequence
+    func keyIterator(start: String? = nil, end: String? = nil, reversed: Bool = false) -> KeySequence {
+        let query = Query(startKey: start, endKey: end, reversed: reversed, database: self)
+        return KeySequence(query: query)
+    }
+
+    // MARK: - Class methods
 
     /// Create a database within given environment
     ///

--- a/Sources/Database.swift
+++ b/Sources/Database.swift
@@ -11,25 +11,6 @@ import Foundation
 import CLMDB
 #endif
 
-/// Convert bytes at given memory pointer to `MDB_val` structure
-///
-/// - Parameter buf: Pointer to the data
-/// - Returns: Instance of MDB_val with given size and bytes data
-internal func rawPointerToMdb(_ buf: UnsafeRawBufferPointer) -> MDB_val {
-    return MDB_val(
-        mv_size: buf.count,
-        mv_data: UnsafeMutableRawPointer(mutating: buf.baseAddress)
-    )
-}
-
-/// Return the in-memory pointer from given MDB_val
-///
-/// - Parameter mdb: MDB_val instance
-/// - Returns: Unsafe pointer
-internal func mdbToRawPointer(_ mdb: MDB_val) -> UnsafeRawBufferPointer {
-    return UnsafeRawBufferPointer(start: mdb.mv_data, count: mdb.mv_size)
-}
-
 /// Database
 public class Database {
 
@@ -310,7 +291,7 @@ public class Database {
     ///   - reversed: Reverse order
     /// - Returns: Instance of the `KeySequence`
     func keyIterator(start: String? = nil, end: String? = nil, reversed: Bool = false) -> KeySequence {
-        let query = Query(startKey: start, endKey: end, reversed: reversed, database: self)
+        let query = Query(start: start, end: end, reversed: reversed, database: self)
         return KeySequence(query: query)
     }
 
@@ -322,7 +303,29 @@ public class Database {
     ///   - reversed: Reverse order
     /// - Returns: Instance of the `KeyValueSequence`
     func keyValueIterator(start: String? = nil, end: String? = nil, reversed: Bool = false) -> KeyValueSequence {
-        let query = Query(startKey: start, endKey: end, reversed: reversed, database: self)
+        let query = Query(start: start, end: end, reversed: reversed, database: self)
+        return KeyValueSequence(query: query)
+    }
+
+    /// Get a range of keys and values.
+    /// Typically used with more precise queries
+    /// NOTE: LTE/GTE values is favoured over LT/GT if both pairs are given
+    ///
+    /// - Parameters:
+    ///   - gte: Greater-than or equal to the key
+    ///   - gt: Greater-than the key
+    ///   - lte: Lower-than or equal to the key
+    ///   - lt: Lower-than the key
+    ///   - reversed: Reverse order
+    /// - Returns: Instance of `KeyValueSequence`
+    func range(
+        gte: Slice? = nil,
+        gt: Slice? = nil,
+        lte: Slice? = nil,
+        lt: Slice? = nil,
+        reversed: Bool = false
+    ) -> KeyValueSequence {
+        let query = Query(gte: gte, gt: gte, lte: lte, lt: lte, reversed: reversed, database: self)
         return KeyValueSequence(query: query)
     }
 

--- a/Sources/KeyIterator.swift
+++ b/Sources/KeyIterator.swift
@@ -46,6 +46,9 @@ public struct KeyIterator: IteratorProtocol {
             if let endKey = cursor.query.endKey {
                 if let dataKey = data?.key {
 
+                    // Cater for reverse ordering
+                    let upperBound: ComparisonResult = cursor.query.reversed ? .orderedDescending : .orderedAscending
+
                     // Compare the returned key with the range end key
                     let result = cursor.compare(endKey, with: dataKey)
 
@@ -54,7 +57,7 @@ public struct KeyIterator: IteratorProtocol {
                         return dataKey
 
                     // If the next key is above the endKey range
-                    } else if result == .orderedAscending {
+                    } else if result == upperBound {
                         return nil
                     }
                 }

--- a/Sources/KeyIterator.swift
+++ b/Sources/KeyIterator.swift
@@ -1,0 +1,71 @@
+//
+//  KeyIterator.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 16/07/2017.
+//
+//
+
+import Foundation
+
+/// Key-only Iterator
+public struct KeyIterator: IteratorProtocol {
+
+    var isEmpty: Bool
+    var cursor: Cursor!
+    var lastValue: Element?
+    var operation: CursorOperation!
+    var nextOperation: CursorOperation!
+
+    public typealias Element = Data
+
+    public init(cursor: Cursor, operation: CursorOperation, nextOperation: CursorOperation) {
+        self.isEmpty = false
+        self.cursor = cursor
+        self.lastValue = cursor.query.startKey?.data()
+        self.operation = operation
+        self.nextOperation = nextOperation
+    }
+
+    /// Initialise an empty instance
+    public init() {
+        self.isEmpty = true
+    }
+
+    /// Retrieves next item in the cursor
+    ///
+    /// - Returns: Key's data or nil if not found
+    public mutating func next() -> Data? {
+        guard !isEmpty && cursor.isValid else {
+            return nil
+        }
+
+        do {
+            let data = try cursor.get(cursor.query.startKey, operation)
+
+            if let endKey = cursor.query.endKey {
+                if let dataKey = data?.key {
+
+                    // Compare the returned key with the range end key
+                    let result = cursor.compare(endKey, with: dataKey)
+
+                    // If its the same as the end key, include it
+                    if result == .orderedSame {
+                        return dataKey
+
+                    // If the next key is above the endKey range
+                    } else if result == .orderedAscending {
+                        return nil
+                    }
+                }
+            }
+
+            self.operation = nextOperation
+            self.lastValue = data?.key?.data()
+
+            return data?.key ?? nil
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/KeyIterator.swift
+++ b/Sources/KeyIterator.swift
@@ -21,7 +21,14 @@ public struct KeyIterator: IteratorProtocol {
     public init(cursor: Cursor, operation: CursorOperation, nextOperation: CursorOperation) {
         self.isEmpty = false
         self.cursor = cursor
-        self.operation = operation
+
+        // Handle GT query range and at init time simply skip the first key
+        var startOperation = operation
+        if cursor.query.start != nil && !cursor.query.isGte {
+            startOperation = cursor.nextOperation
+        }
+
+        self.operation = startOperation
         self.nextOperation = nextOperation
     }
 
@@ -39,9 +46,9 @@ public struct KeyIterator: IteratorProtocol {
         }
 
         do {
-            let data = try cursor.get(cursor.query.startKey, operation)
+            let data = try cursor.get(cursor.query.start, operation)
 
-            if let endKey = cursor.query.endKey {
+            if let endKey = cursor.query.end {
                 if let dataKey = data?.key {
 
                     // Cater for reverse ordering
@@ -51,11 +58,12 @@ public struct KeyIterator: IteratorProtocol {
                     let result = cursor.compare(endKey, with: dataKey)
 
                     // If its the same as the end key, include it
-                    if result == .orderedSame {
+                    if cursor.query.isLte && result == .orderedSame {
                         return dataKey
 
                     // If the next key is above the endKey range
-                    } else if result == upperBound {
+                    // OR, if the query is not LTE but the key is equal to the end range
+                    } else if result == upperBound || (!cursor.query.isLte && result == .orderedSame) {
                         return nil
                     }
                 }

--- a/Sources/KeySequence.swift
+++ b/Sources/KeySequence.swift
@@ -1,0 +1,44 @@
+//
+//  KeySequence.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 15/07/2017.
+//
+//
+
+import Foundation
+#if SWIFT_PACKAGE
+import CLMDB
+#endif
+
+/// Key Sequence type
+public struct KeySequence: Sequence {
+
+    /// Defines the type of the iterator
+    public typealias Iterator = KeyIterator
+
+    /// Query to run the iterator with
+    private let query: Query
+
+    /// Initialise a key-only sequence
+    ///
+    /// - Parameter query: Query to run the iterator with
+    init(query: Query) {
+        self.query = query
+    }
+
+    /// Returns an iterator over the elements of this sequence.
+    ///
+    /// - Returns: Iterator instance
+    public func makeIterator() -> Iterator {
+        do {
+            let transaction = try Transaction(environment: query.database.environment)
+            let cursor = Cursor(transaction: transaction, query: self.query)
+
+            return KeyIterator(cursor: cursor, operation: cursor.operation, nextOperation: cursor.nextOperation)
+        } catch {
+            // Return an empty iterator
+            return KeyIterator()
+        }
+    }
+}

--- a/Sources/KeySequence.swift
+++ b/Sources/KeySequence.swift
@@ -7,9 +7,6 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
-import CLMDB
-#endif
 
 /// Key Sequence type
 public struct KeySequence: Sequence {

--- a/Sources/KeyValueIterator.swift
+++ b/Sources/KeyValueIterator.swift
@@ -1,22 +1,22 @@
 //
-//  KeyIterator.swift
+//  KeyValueIterator.swift
 //  BlueJet
 //
-//  Created by Przemyslaw Bobak on 16/07/2017.
+//  Created by Przemyslaw Bobak on 17/07/2017.
 //
 //
 
 import Foundation
 
-/// Key-only Iterator
-public struct KeyIterator: IteratorProtocol {
+/// Key & Value Iterator
+public struct KeyValueIterator: IteratorProtocol {
 
     var isEmpty: Bool
     var cursor: Cursor!
     var operation: CursorOperation!
     var nextOperation: CursorOperation!
 
-    public typealias Element = Data
+    public typealias Element = (key: Data, value: Data?)
 
     public init(cursor: Cursor, operation: CursorOperation, nextOperation: CursorOperation) {
         self.isEmpty = false
@@ -52,7 +52,7 @@ public struct KeyIterator: IteratorProtocol {
 
                     // If its the same as the end key, include it
                     if result == .orderedSame {
-                        return dataKey
+                        return data
 
                     // If the next key is above the endKey range
                     } else if result == upperBound {
@@ -64,7 +64,7 @@ public struct KeyIterator: IteratorProtocol {
             // Set current operation to the next operation
             self.operation = nextOperation
 
-            return data?.key ?? nil
+            return data
         } catch {
             return nil
         }

--- a/Sources/KeyValueSequence.swift
+++ b/Sources/KeyValueSequence.swift
@@ -7,9 +7,6 @@
 //
 
 import Foundation
-#if SWIFT_PACKAGE
-    import CLMDB
-#endif
 
 /// Key Sequence type
 public struct KeyValueSequence: Sequence {

--- a/Sources/KeyValueSequence.swift
+++ b/Sources/KeyValueSequence.swift
@@ -1,21 +1,21 @@
 //
-//  KeySequence.swift
+//  KeyValueSequence.swift
 //  BlueJet
 //
-//  Created by Przemyslaw Bobak on 15/07/2017.
+//  Created by Przemyslaw Bobak on 17/07/2017.
 //
 //
 
 import Foundation
 #if SWIFT_PACKAGE
-import CLMDB
+    import CLMDB
 #endif
 
 /// Key Sequence type
-public struct KeySequence: Sequence {
+public struct KeyValueSequence: Sequence {
 
     /// Defines the type of the iterator
-    public typealias Iterator = KeyIterator
+    public typealias Iterator = KeyValueIterator
 
     /// Query to run the iterator with
     private let query: Query

--- a/Sources/Query.swift
+++ b/Sources/Query.swift
@@ -1,0 +1,45 @@
+//
+//  Query.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 15/07/2017.
+//
+//
+
+import Foundation
+#if SWIFT_PACKAGE
+import CLMDB
+#endif
+
+/// Query structure
+public struct Query {
+
+    /// Database to query the data against
+    public let database: Database
+
+    /// Start of the range
+    public let startKey: Slice?
+
+    /// End of the range
+    public let endKey: Slice?
+
+    /// Reverses the order in which results are listed
+    public let reversed: Bool
+
+    // TODO: Add lte/gte options
+    // public let includeEndRange: Bool
+
+    /// Initialise a query with given params
+    ///
+    /// - Parameters:
+    ///   - startKey: Start of the range
+    ///   - endKey: End of the range
+    ///   - reversed: Reverse order
+    ///   - database: Database to lookup the keys for
+    public init(startKey: Slice?, endKey: Slice?, reversed: Bool, database: Database) {
+        self.startKey = startKey
+        self.endKey = endKey
+        self.reversed = reversed
+        self.database = database
+    }
+}

--- a/Sources/Query.swift
+++ b/Sources/Query.swift
@@ -18,28 +18,60 @@ public struct Query {
     public let database: Database
 
     /// Start of the range
-    public let startKey: Slice?
+    public let start: Slice?
 
     /// End of the range
-    public let endKey: Slice?
+    public let end: Slice?
 
     /// Reverses the order in which results are listed
     public let reversed: Bool
 
-    // TODO: Add lte/gte options
-    // public let includeEndRange: Bool
+    /// Is less-than or equal
+    public let isLte: Bool
+
+    /// Is greater-than or equal
+    public let isGte: Bool
 
     /// Initialise a query with given params
     ///
     /// - Parameters:
-    ///   - startKey: Start of the range
-    ///   - endKey: End of the range
+    ///   - start: Start of the range
+    ///   - end: End of the range
     ///   - reversed: Reverse order
     ///   - database: Database to lookup the keys for
-    public init(startKey: Slice?, endKey: Slice?, reversed: Bool, database: Database) {
-        self.startKey = startKey
-        self.endKey = endKey
+    public init(start: Slice?, end: Slice?, reversed: Bool, database: Database) {
+        self.start = start
+        self.end = end
         self.reversed = reversed
         self.database = database
+        self.isLte = true
+        self.isGte = true
+    }
+
+    /// Initialise with more precise range keys
+    ///
+    /// - Parameters:
+    ///   - gte: Greater-than or equal to the key
+    ///   - gt: Greater-than the key
+    ///   - lte: Lower-than or equal to the key
+    ///   - lt: Lower-than the key
+    ///   - reversed: Reverse order
+    ///   - database: Database to lookup the keys for
+    public init(
+        gte: Slice? = nil,
+        gt: Slice? = nil,
+        lte: Slice? = nil,
+        lt: Slice? = nil,
+        reversed: Bool,
+        database: Database
+    ) {
+        // Favour lte over lt if both are present
+        self.start = gt ?? gte
+        // Favour gte over gt if both are present
+        self.end = lt ?? lte
+        self.reversed = reversed
+        self.database = database
+        self.isGte = gte != nil
+        self.isLte = lte != nil
     }
 }

--- a/Sources/Slice.swift
+++ b/Sources/Slice.swift
@@ -61,8 +61,13 @@ extension Data: Slice {
     ///
     /// - Parameter data: Instance of the in-memory poointer
     public init?(data: UnsafeRawBufferPointer) {
+        // If memory has been wrongly allocated, just return nil
+        guard data.baseAddress != nil else {
+            return nil
+        }
+
         // This copies the bytes out immediately.
-        self = Data.init(bytes: data.baseAddress!, count: data.count)
+        self = Data(bytes: data.baseAddress!, count: data.count)
     }
 }
 

--- a/Sources/Slice.swift
+++ b/Sources/Slice.swift
@@ -29,6 +29,12 @@ public protocol Slice {
     func data() -> Data
 }
 
+extension Slice {
+    public func mdbValue() -> MDB_val {
+        return slice({ rawPointerToMdb($0) })
+    }
+}
+
 // MARK: - Data extension
 
 extension Data: Slice {
@@ -59,7 +65,6 @@ extension Data: Slice {
         self = Data.init(bytes: data.baseAddress!, count: data.count)
     }
 }
-
 
 // MARK: - String extension
 

--- a/Sources/Transaction.swift
+++ b/Sources/Transaction.swift
@@ -96,14 +96,6 @@ public struct Transaction {
         mdb_txn_renew(pointer)
     }
 
-    public func compare(_ key: Slice, with otherKey: Slice, in database: Database) -> ComparisonResult? {
-        var keyValue = key.mdbValue()
-        var otherKeyValue = key.mdbValue()
-        let value = Int(mdb_cmp(pointer, database.pointer, &keyValue, &otherKeyValue))
-
-        return ComparisonResult(rawValue: value)
-    }
-
     public func cursor(query: Query) -> Cursor {
         return Cursor(transaction: self, query: query)
     }

--- a/Sources/Transaction.swift
+++ b/Sources/Transaction.swift
@@ -96,7 +96,7 @@ public struct Transaction {
         mdb_txn_renew(pointer)
     }
 
-    public func cursor(query: Query) -> Cursor {
+    public func cursor(for query: Query) -> Cursor {
         return Cursor(transaction: self, query: query)
     }
 

--- a/Sources/Utility.swift
+++ b/Sources/Utility.swift
@@ -1,0 +1,31 @@
+//
+//  Utility.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 18/07/2017.
+//
+//
+
+import Foundation
+#if SWIFT_PACKAGE
+    import CLMDB
+#endif
+
+/// Convert bytes at given memory pointer to `MDB_val` structure
+///
+/// - Parameter buf: Pointer to the data
+/// - Returns: Instance of MDB_val with given size and bytes data
+internal func rawPointerToMdb(_ buf: UnsafeRawBufferPointer) -> MDB_val {
+    return MDB_val(
+        mv_size: buf.count,
+        mv_data: UnsafeMutableRawPointer(mutating: buf.baseAddress)
+    )
+}
+
+/// Return the in-memory pointer from given MDB_val
+///
+/// - Parameter mdb: MDB_val instance
+/// - Returns: Unsafe pointer
+internal func mdbToRawPointer(_ mdb: MDB_val) -> UnsafeRawBufferPointer {
+    return UnsafeRawBufferPointer(start: mdb.mv_data, count: mdb.mv_size)
+}

--- a/Tests/BlueJetTests/DatabaseTests.swift
+++ b/Tests/BlueJetTests/DatabaseTests.swift
@@ -19,7 +19,7 @@ class DatabaseTests: XCTestCase {
         super.setUp()
 
         do {
-            environment = try Environment(path: Helpers.getPath())
+            environment = try Environment(path: Helpers.getPath(name))
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -28,7 +28,8 @@ class DatabaseTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
 
-        try? FileManager.default.removeItem(atPath: Helpers.getPath())
+        environment.close()
+        try? FileManager.default.removeItem(atPath: Helpers.getPath(name))
     }
 
     func testInitialiseDatabase() {

--- a/Tests/BlueJetTests/EnvironmentTests.swift
+++ b/Tests/BlueJetTests/EnvironmentTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class EnvironmentTests: XCTestCase {
 
-    override class func tearDown() {
+    override func tearDown() {
         super.tearDown()
 
         try? FileManager.default.removeItem(atPath: Helpers.getPath())

--- a/Tests/BlueJetTests/Helpers.swift
+++ b/Tests/BlueJetTests/Helpers.swift
@@ -19,6 +19,13 @@ func escapeName(_ text: String?) -> String? {
         .replacingOccurrences(of: " ", with: "")
 }
 
+func mapDataToString(_ pair: (key: Data, value: Data?)) -> Entry {
+    return (
+        key: String(data: pair.key, encoding: .utf8)!,
+        value: pair.value != nil ? String(data: pair.value!, encoding: .utf8) : nil
+    )
+}
+
 struct Helpers {
 
     static func getDBName(_ instance: XCTestCase, _ name: String?) -> String {
@@ -32,8 +39,6 @@ struct Helpers {
 
         do {
             try FileManager.default.createDirectory(at: envURL, withIntermediateDirectories: true, attributes: nil)
-
-            print("Created db at path: \(envURL.path)")
         } catch {
             XCTFail("Could not create DB dir: \(error)")
         }
@@ -46,19 +51,18 @@ func == (lhs: Entry, rhs: Entry) -> Bool {
     return lhs.key == rhs.key && lhs.value == rhs.value
 }
 
-func assertEqual(_ a: [Entry], _ b: [Entry]) -> Bool {
-    guard a.count == b.count else {
+func assertEqual(_ entry: [Entry], _ anotherEntry: [Entry]) -> Bool {
+    guard entry.count == anotherEntry.count else {
         return false
     }
 
     var valid: Bool = true
 
-    a.enumerated().forEach { (offset: Int, element: Entry) in
+    entry.enumerated().forEach { (offset: Int, _: Entry) in
         if valid {
-            valid = a[offset] == b[offset]
+            valid = entry[offset] == anotherEntry[offset]
         }
     }
 
     return valid
 }
-

--- a/Tests/BlueJetTests/Helpers.swift
+++ b/Tests/BlueJetTests/Helpers.swift
@@ -9,13 +9,31 @@
 import Foundation
 import XCTest
 
+typealias Entry = (key: String, value: String?)
+
+func escapeName(_ text: String?) -> String? {
+    return text?
+        .replacingOccurrences(of: "[", with: "")
+        .replacingOccurrences(of: "]", with: "")
+        .replacingOccurrences(of: "-", with: "")
+        .replacingOccurrences(of: " ", with: "")
+}
+
 struct Helpers {
+
+    static func getDBName(_ instance: XCTestCase, _ name: String?) -> String {
+        return escapeName(name) ?? String(describing: instance)
+    }
+
     static func getPath(_ name: String? = nil) -> String {
+        let safeFileName = escapeName(name)
         let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
-        let envURL = tempURL.appendingPathComponent(name ?? "BlueJetTests")
+        let envURL = tempURL.appendingPathComponent(safeFileName ?? "BlueJetTests")
 
         do {
             try FileManager.default.createDirectory(at: envURL, withIntermediateDirectories: true, attributes: nil)
+
+            print("Created db at path: \(envURL.path)")
         } catch {
             XCTFail("Could not create DB dir: \(error)")
         }
@@ -23,3 +41,24 @@ struct Helpers {
         return envURL.path
     }
 }
+
+func == (lhs: Entry, rhs: Entry) -> Bool {
+    return lhs.key == rhs.key && lhs.value == rhs.value
+}
+
+func assertEqual(_ a: [Entry], _ b: [Entry]) -> Bool {
+    guard a.count == b.count else {
+        return false
+    }
+
+    var valid: Bool = true
+
+    a.enumerated().forEach { (offset: Int, element: Entry) in
+        if valid {
+            valid = a[offset] == b[offset]
+        }
+    }
+
+    return valid
+}
+

--- a/Tests/BlueJetTests/KeySequenceTests.swift
+++ b/Tests/BlueJetTests/KeySequenceTests.swift
@@ -1,0 +1,67 @@
+//
+//  KeySequenceTests.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 15/07/2017.
+//
+//
+
+import XCTest
+
+@testable import BlueJet
+
+//swiftlint:disable force_try
+class KeySequenceTests: XCTestCase {
+
+    var environment: Environment!
+    var database: Database!
+
+    override func setUp() {
+        super.setUp()
+
+        environment = try! Environment(path: Helpers.getPath())
+        database = try! Database.create(name: "Keys", environment: environment)
+        try! database.put("A", "0".data())
+        try! database.put("B", "1".data())
+        try! database.put("C", "2".data())
+        try! database.put("D", "3".data())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        try? FileManager.default.removeItem(atPath: Helpers.getPath())
+    }
+
+    func testEnumeration() {
+        let sequence = database.keyIterator()
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 4)
+        XCTAssertEqual(keys, ["A", "B", "C", "D"])
+    }
+
+    func testReverseEnumeration() {
+        let sequence = database.keyIterator(reversed: true)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 4)
+        XCTAssertEqual(keys, ["D", "C", "B", "A"])
+    }
+
+    func testStartKey() {
+        let sequence = database.keyIterator(start: "B")
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["B", "C", "D"])
+    }
+
+    func testEndKey() {
+        let sequence = database.keyIterator(start: "A", end: "C")
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["A", "B", "C"])
+    }
+}

--- a/Tests/BlueJetTests/KeySequenceTests.swift
+++ b/Tests/BlueJetTests/KeySequenceTests.swift
@@ -15,21 +15,30 @@ class KeySequenceTests: XCTestCase {
 
     var environment: Environment!
     var database: Database!
+    var dbName: String!
 
     override func setUp() {
         super.setUp()
 
-        environment = try! Environment(path: Helpers.getPath())
-        database = try! Database.create(name: "Keys", environment: environment)
-        try! database.put("A", "0".data())
-        try! database.put("B", "1".data())
-        try! database.put("C", "2".data())
-        try! database.put("D", "3".data())
+        dbName = Helpers.getDBName(self, name)
+
+        do {
+            environment = try Environment(path: Helpers.getPath())
+            database = try Database.create(name: dbName, environment: environment)
+            try database.put("A", "0".data())
+            try database.put("B", "1".data())
+            try database.put("C", "2".data())
+            try database.put("D", "3".data())
+        } catch {
+            fatalError(error.localizedDescription)
+        }
     }
 
     override func tearDown() {
         super.tearDown()
 
+        database.close()
+        environment.close()
         try? FileManager.default.removeItem(atPath: Helpers.getPath())
     }
 
@@ -49,6 +58,8 @@ class KeySequenceTests: XCTestCase {
         XCTAssertEqual(keys, ["D", "C", "B", "A"])
     }
 
+    // MARK: - Start Key
+
     func testStartKey() {
         let sequence = database.keyIterator(start: "B")
         let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
@@ -65,6 +76,8 @@ class KeySequenceTests: XCTestCase {
         XCTAssertEqual(keys, ["B", "A"])
     }
 
+    // MARK: - End Key
+
     func testEndKey() {
         let sequence = database.keyIterator(start: "A", end: "C")
         let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
@@ -72,6 +85,8 @@ class KeySequenceTests: XCTestCase {
         XCTAssertEqual(keys.count, 3)
         XCTAssertEqual(keys, ["A", "B", "C"])
     }
+
+    // MARK: - Full Range
 
     func testRangeWithReverseOrder() {
         let sequence = database.keyIterator(start: "C", end: "B", reversed: true)

--- a/Tests/BlueJetTests/KeySequenceTests.swift
+++ b/Tests/BlueJetTests/KeySequenceTests.swift
@@ -57,11 +57,35 @@ class KeySequenceTests: XCTestCase {
         XCTAssertEqual(keys, ["B", "C", "D"])
     }
 
+    func testReverseStartKey() {
+        let sequence = database.keyIterator(start: "B", reversed: true)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys, ["B", "A"])
+    }
+
     func testEndKey() {
         let sequence = database.keyIterator(start: "A", end: "C")
         let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
 
         XCTAssertEqual(keys.count, 3)
         XCTAssertEqual(keys, ["A", "B", "C"])
+    }
+
+    func testRangeWithReverseOrder() {
+        let sequence = database.keyIterator(start: "C", end: "B", reversed: true)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys, ["C", "B"])
+    }
+
+    func testEndRangeReverseOrder() {
+        let sequence = database.keyIterator(end: "B", reversed: true)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["D", "C", "B"])
     }
 }

--- a/Tests/BlueJetTests/KeySequenceTests.swift
+++ b/Tests/BlueJetTests/KeySequenceTests.swift
@@ -103,4 +103,42 @@ class KeySequenceTests: XCTestCase {
         XCTAssertEqual(keys.count, 3)
         XCTAssertEqual(keys, ["D", "C", "B"])
     }
+
+    // MARK: - Precise Range
+
+    func testLtRangeIteration() {
+        let query = Query(lt: "C", reversed: false, database: database)
+        let sequence = KeySequence(query: query)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys, ["A", "B"])
+    }
+
+    func testLtReverseRangeIteration() {
+        let query = Query(lt: "A", reversed: true, database: database)
+        let sequence = KeySequence(query: query)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["D", "C", "B"])
+    }
+
+    func testGtRangeIteration() {
+        let query = Query(gt: "A", reversed: false, database: database)
+        let sequence = KeySequence(query: query)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["B", "C", "D"])
+    }
+
+    func testGtReverseRangeIteration() {
+        let query = Query(gt: "D", reversed: true, database: database)
+        let sequence = KeySequence(query: query)
+        let keys: [String] = sequence.map { String(data: $0, encoding: .utf8)! }
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertEqual(keys, ["C", "B", "A"])
+    }
 }

--- a/Tests/BlueJetTests/KeyValueSequenceTests.swift
+++ b/Tests/BlueJetTests/KeyValueSequenceTests.swift
@@ -43,7 +43,7 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testEnumeration() {
         let sequence = database.keyValueIterator()
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "A", value: "0"),
             (key: "B", value: "1"),
@@ -56,12 +56,12 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testReverseEnumeration() {
         let sequence = database.keyValueIterator(reversed: true)
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "D", value: "3"),
             (key: "C", value: "2"),
             (key: "B", value: "1"),
-            (key: "A", value: "0"),
+            (key: "A", value: "0")
         ]
 
         XCTAssertEqual(keys.count, 4)
@@ -72,11 +72,11 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testStartKey() {
         let sequence = database.keyValueIterator(start: "B")
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "B", value: "1"),
             (key: "C", value: "2"),
-            (key: "D", value: "3"),
+            (key: "D", value: "3")
         ]
 
         XCTAssertEqual(keys.count, 3)
@@ -85,10 +85,10 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testReverseStartKey() {
         let sequence = database.keyValueIterator(start: "B", reversed: true)
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "B", value: "1"),
-            (key: "A", value: "0"),
+            (key: "A", value: "0")
         ]
 
         XCTAssertEqual(keys.count, 2)
@@ -99,11 +99,11 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testEndKey() {
         let sequence = database.keyValueIterator(start: "A", end: "C")
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "A", value: "0"),
             (key: "B", value: "1"),
-            (key: "C", value: "2"),
+            (key: "C", value: "2")
         ]
 
         XCTAssertEqual(keys.count, 3)
@@ -114,10 +114,10 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testRangeWithReverseOrder() {
         let sequence = database.keyValueIterator(start: "C", end: "B", reversed: true)
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "C", value: "2"),
-            (key: "B", value: "1"),
+            (key: "B", value: "1")
         ]
 
         XCTAssertEqual(keys.count, 2)
@@ -126,11 +126,11 @@ class KeyValueSequenceTests: XCTestCase {
 
     func testEndRangeReverseOrder() {
         let sequence = database.keyValueIterator(end: "B", reversed: true)
-        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let keys: [Entry] = sequence.map { mapDataToString($0) }
         let expected: [Entry] = [
             (key: "D", value: "3"),
             (key: "C", value: "2"),
-            (key: "B", value: "1"),
+            (key: "B", value: "1")
         ]
 
         XCTAssertEqual(keys.count, 3)

--- a/Tests/BlueJetTests/KeyValueSequenceTests.swift
+++ b/Tests/BlueJetTests/KeyValueSequenceTests.swift
@@ -136,4 +136,57 @@ class KeyValueSequenceTests: XCTestCase {
         XCTAssertEqual(keys.count, 3)
         XCTAssertTrue(assertEqual(keys, expected))
     }
+
+    // MARK: - Precise Range
+
+    func testLtRangeIteration() {
+        let query = Query(lt: "C", reversed: false, database: database)
+        let keys = KeyValueSequence(query: query).map { mapDataToString($0) }
+        let expected: [Entry] = [
+            (key: "A", value: "0"),
+            (key: "B", value: "1")
+        ]
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testLtReverseRangeIteration() {
+        let query = Query(lt: "A", reversed: true, database: database)
+        let keys = KeyValueSequence(query: query).map { mapDataToString($0) }
+        let expected: [Entry] = [
+            (key: "D", value: "3"),
+            (key: "C", value: "2"),
+            (key: "B", value: "1")
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testGtRangeIteration() {
+        let query = Query(gt: "A", reversed: false, database: database)
+        let keys = KeyValueSequence(query: query).map { mapDataToString($0) }
+        let expected: [Entry] = [
+            (key: "B", value: "1"),
+            (key: "C", value: "2"),
+            (key: "D", value: "3")
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testGtReverseRangeIteration() {
+        let query = Query(gt: "D", reversed: true, database: database)
+        let keys = KeyValueSequence(query: query).map { mapDataToString($0) }
+        let expected: [Entry] = [
+            (key: "C", value: "2"),
+            (key: "B", value: "1"),
+            (key: "A", value: "0")
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
 }

--- a/Tests/BlueJetTests/KeyValueSequenceTests.swift
+++ b/Tests/BlueJetTests/KeyValueSequenceTests.swift
@@ -1,0 +1,139 @@
+//
+//  KeyValueSequenceTests.swift
+//  BlueJet
+//
+//  Created by Przemyslaw Bobak on 17/07/2017.
+//
+//
+
+import XCTest
+
+@testable import BlueJet
+
+class KeyValueSequenceTests: XCTestCase {
+
+    var environment: Environment!
+    var database: Database!
+    var dbName: String!
+
+    override func setUp() {
+        super.setUp()
+
+        dbName = Helpers.getDBName(self, name)
+
+        do {
+            environment = try Environment(path: Helpers.getPath())
+            database = try Database.create(name: dbName, environment: environment)
+            try database.put("A", "0".data())
+            try database.put("B", "1".data())
+            try database.put("C", "2".data())
+            try database.put("D", "3".data())
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        database.close()
+        environment.close()
+        try? FileManager.default.removeItem(atPath: Helpers.getPath())
+    }
+
+    func testEnumeration() {
+        let sequence = database.keyValueIterator()
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "A", value: "0"),
+            (key: "B", value: "1"),
+            (key: "C", value: "2"),
+            (key: "D", value: "3")
+        ]
+
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testReverseEnumeration() {
+        let sequence = database.keyValueIterator(reversed: true)
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "D", value: "3"),
+            (key: "C", value: "2"),
+            (key: "B", value: "1"),
+            (key: "A", value: "0"),
+        ]
+
+        XCTAssertEqual(keys.count, 4)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    // MARK: - Start Key
+
+    func testStartKey() {
+        let sequence = database.keyValueIterator(start: "B")
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "B", value: "1"),
+            (key: "C", value: "2"),
+            (key: "D", value: "3"),
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testReverseStartKey() {
+        let sequence = database.keyValueIterator(start: "B", reversed: true)
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "B", value: "1"),
+            (key: "A", value: "0"),
+        ]
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    // MARK: - End Key
+
+    func testEndKey() {
+        let sequence = database.keyValueIterator(start: "A", end: "C")
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "A", value: "0"),
+            (key: "B", value: "1"),
+            (key: "C", value: "2"),
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    // MARK: - Full Range
+
+    func testRangeWithReverseOrder() {
+        let sequence = database.keyValueIterator(start: "C", end: "B", reversed: true)
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "C", value: "2"),
+            (key: "B", value: "1"),
+        ]
+
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+
+    func testEndRangeReverseOrder() {
+        let sequence = database.keyValueIterator(end: "B", reversed: true)
+        let keys: [Entry] = sequence.map { (String(data: $0, encoding: .utf8)!, String(data: $1 ?? Data(), encoding: .utf8)) }
+        let expected: [Entry] = [
+            (key: "D", value: "3"),
+            (key: "C", value: "2"),
+            (key: "B", value: "1"),
+        ]
+
+        XCTAssertEqual(keys.count, 3)
+        XCTAssertTrue(assertEqual(keys, expected))
+    }
+}


### PR DESCRIPTION
Enumeration uses byte comparison (`memcmp`) rather than the `mdb_cmp` function provided by LMDB as it seemed to only compare integer values. The former approach makes comparing string keys possible.

Remaining TODOs:

- [x] Key AND Value iterator/sequence
- [x] `lt/lte` & `gt/gte` query options
